### PR TITLE
Bugfix/username has already been taken

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -2,5 +2,5 @@ class Authorization < ApplicationRecord
   belongs_to :user
 
   validates :uid, presence: true
-  validates :provider, presence: true, uniqueness: { scope: :uid }
+  validates :provider, presence: true, uniqueness: { scope: :uid, message: "Provider already exists for this uid." }
 end

--- a/app/services/find_for_oauth_service.rb
+++ b/app/services/find_for_oauth_service.rb
@@ -19,7 +19,8 @@ class FindForOauthService
         password = Devise.friendly_token[0, 20]
         username = get_username(auth)
         user = User.create!(username: username, email: email,
-                            password: password, password_confirmation: password)
+                            password: password, password_confirmation: password,
+                            confirmed_at: Time.current)
       end
 
       user.authorizations.create!(provider: auth.provider, uid: auth.uid.to_s)

--- a/app/services/find_for_oauth_service.rb
+++ b/app/services/find_for_oauth_service.rb
@@ -1,9 +1,13 @@
 class FindForOauthService
+  #REFACTOR
   def self.call(auth)
     authorization = Authorization.find_by(provider: auth.provider, uid: auth.uid.to_s)
     return authorization.user if authorization
 
     if auth.try(:info).try(:email).blank?
+      # TODO if Oauth Provider doesnt return e-mail
+      # For example, add redirect from create_auth to an action with a form in OauthCallbacksController
+      # and session['omniauth.auth'] = request.env['omniauth.auth']
       return User.new
     else
       email = auth.info.email
@@ -31,10 +35,17 @@ class FindForOauthService
 
     # auth.info.name returns any of the available values: name, first_name, nickname, email
     # https://github.com/omniauth/omniauth/blob/7d90ba21c26299df8001684cbfbb6c54ce8ea440/lib/omniauth/auth_hash.rb#L32
-    if auth.info.try(:nickname).present?
-      auth.info.nickname
-    else
-      auth.info.email.split('@').first.tr('.+', '_')
-    end
+    username = if auth.info.try(:nickname).present?
+                auth.info.nickname
+               else
+                auth.info.email.split('@').first.tr('.+', '_')
+               end
+
+    #TODO better to prompt the user for username or redirect to edit_user_registration_path after registration
+    make_username_unique(username, auth.uid)
+  end
+
+  def self.make_username_unique(username, uid)
+    User.exists?(username: username) ? "#{username}_#{uid}" : username
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -185,7 +185,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 10..128
+  config.password_length = 20..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
     sequence(:username) { |n| "#{n}_username" }
     sequence(:email) { |n| "#{n}_user@example.edu" }
 
-    password { '0987654321' }
-    password_confirmation { '0987654321' }
+    password { '0987654321ZYXWVUTSRQ' }
+    password_confirmation { '0987654321ZYXWVUTSRQ' }
     confirmed_at { Time.now }
 
 

--- a/spec/features/user/log_in_oauth_spec.rb
+++ b/spec/features/user/log_in_oauth_spec.rb
@@ -13,13 +13,6 @@ feature 'User can sign in with OAuth providers', %q{
     mock_auth_hash(provider: 'github', email: user_email)
 
     click_on 'Sign in with GitHub'
-    expect(page).to have_content 'You have to confirm your email address before continuing.'
-
-    open_email user_email
-    current_email.click_link 'Confirm my account'
-    expect(page).to have_content 'Your email address has been successfully confirmed.'
-
-    click_on 'Sign in with GitHub'
     expect(page).to have_content 'Successfully authenticated from Github account.'
   end
 

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Authorization, type: :model do
     describe "uniqueness" do
       subject { Authorization.new(provider: "github", uid: "220926", user: create(:user)) }
 
-      it { should validate_uniqueness_of(:provider).scoped_to(:uid) }
+      it { should validate_uniqueness_of(:provider).scoped_to(:uid).
+            with_message('Provider already exists for this uid.') }
     end
 
   end

--- a/spec/services/find_for_oauth_service_spec.rb
+++ b/spec/services/find_for_oauth_service_spec.rb
@@ -86,6 +86,47 @@ RSpec.describe FindForOauthService, type: :services do
       end
     end
 
+    context 'user doesnt exist, but username has already been taken' do
+      let(:username)  { 'rnd' }
+      let!(:another_user)  { create(:user, username: username) }
+      let(:auth) { OmniAuth::AuthHash.new(provider: 'github',
+                                          uid: '8282',
+                                          info: { email: "#{username}@mail.space" }) }
+
+      it 'creates new user' do
+        expect { subject }.to change(User, :count).by(1)
+      end
+
+      it 'returns new user' do
+        expect(subject).to be_a(User)
+      end
+
+      it 'fills user email' do
+        user = subject
+        expect(user.email).to eq auth.info[:email]
+      end
+
+      it 'fills user name' do
+        user = subject
+        expect(user.username).to eq "#{username}_#{auth.uid}"
+      end
+
+      it 'creates authorization' do
+        expect{subject}.to change(Authorization, :count).by(1)
+      end
+
+      it 'creates authorization for user' do
+        user = subject
+        expect(user.authorizations).to_not be_empty
+      end
+
+      it 'creates authorization with provider and uid' do
+        authorization = subject.authorizations.first
+        expect(authorization.provider).to eq auth.provider
+        expect(authorization.uid).to eq auth.uid
+      end
+    end
+
     context 'user does not exist and doesn\'t email' do
       let(:auth) { OmniAuth::AuthHash.new(provider: 'github',
                                           uid: '8282') }


### PR DESCRIPTION
If a user was registering through an OAuth provider and nickname was already taken, then an exception was thrown